### PR TITLE
D4-Employee_Registration-7-create manage event registration permission

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -48,5 +48,4 @@ module:
 theme:
   olivero: 0
   claro: 0
-
 profile: standard

--- a/modules/custom/employee_registration/README.md
+++ b/modules/custom/employee_registration/README.md
@@ -72,6 +72,7 @@ information, see
 - Create a block registration_count \Drupal\employee_registration\src\Plugin\Block\RegistrationCount.php
 - Added config Drupal\employee_registration\config\optional\block.block.registrationcount.yml to place block at every page.
 - Create role Development Manger \Drupal\employee_registration\config\optional\user.role.development_manager.yml
+- Create a permission “Manage event registrations” at \Drupal\employee_registration\employee_registration.permissions.yml and assigned role Development manager to it.
 
 
 ## Bugfixes

--- a/modules/custom/employee_registration/config/optional/system.action.user_add_role_action.development_manager.yml
+++ b/modules/custom/employee_registration/config/optional/system.action.user_add_role_action.development_manager.yml
@@ -1,4 +1,4 @@
-uuid: e3ca517f-e945-4665-a613-69d1c13590dc
+uuid: d6c85488-9752-4a2e-abe1-75f3f370dd87
 langcode: en
 status: true
 dependencies:
@@ -6,6 +6,8 @@ dependencies:
     - user.role.development_manager
   module:
     - user
+_core:
+  default_config_hash: 4SNemnLynxmyZdDGKKJ6yytaYZGh71vVhqkhvwQr0PI
 id: user_add_role_action.development_manager
 label: 'Add the Development Manager role to the selected user(s)'
 type: user

--- a/modules/custom/employee_registration/config/optional/system.action.user_remove_role_action.development_manager.yml
+++ b/modules/custom/employee_registration/config/optional/system.action.user_remove_role_action.development_manager.yml
@@ -1,4 +1,4 @@
-uuid: 59be6a25-cc1a-4c29-a889-eded481540ba
+uuid: b520cb1c-1996-4887-8c4a-98be6a69a483
 langcode: en
 status: true
 dependencies:
@@ -6,6 +6,8 @@ dependencies:
     - user.role.development_manager
   module:
     - user
+_core:
+  default_config_hash: R6Y5tpJkpzZas_66e-p2ma-AhFX_unWfoYNsV3pKSaQ
 id: user_remove_role_action.development_manager
 label: 'Remove the Development Manager role from the selected user(s)'
 type: user

--- a/modules/custom/employee_registration/config/optional/user.role.development_manager.yml
+++ b/modules/custom/employee_registration/config/optional/user.role.development_manager.yml
@@ -2,11 +2,13 @@ uuid: 24311c23-3717-4b80-92b7-81511a755dc3
 langcode: en
 status: true
 dependencies:
-  enforced:
-    module:
-      - employee_registration
+  module:
+    - employee_registration
+_core:
+  default_config_hash: wmxMeCsSqXhjArGD9KgLdtEjf4d83wgJjLaBR88RQLs
 id: development_manager
 label: 'Development Manager'
 weight: 4
 is_admin: null
-permissions: {  }
+permissions:
+  - 'manage event registrations'

--- a/modules/custom/employee_registration/employee_registration.permissions.yml
+++ b/modules/custom/employee_registration/employee_registration.permissions.yml
@@ -1,0 +1,3 @@
+manage event registrations:
+  title: 'Manage Event Registrations'
+  description: 'Permission to event managers to manage events.'


### PR DESCRIPTION
- Create a permission “Manage event registrations” at \Drupal\employee_registration\employee_registration.permissions.yml and assigned role Development manager to it.
- Updated README.md